### PR TITLE
chore: switch needle in haystack to use llm_generate

### DIFF
--- a/LLMNeedleHaystackTester.py
+++ b/LLMNeedleHaystackTester.py
@@ -272,12 +272,12 @@ class LLMNeedleHaystackTester:
         # The rails is used to search outputs for specific values and return a binary value
         # It will remove text such as ",,," or "..." and general strings from outputs
         # It answers needle_rnd_number or unanswerable or unparsable (if both or none exist in output)
-        rail_map = [[row['needle_rnd_number'], "UNANSWERABLE"] for index, row in df.iterrows()]
+        rail_map = [[row['needle_rnd_number'], "unanswerable"] for index, row in df.iterrows()]
 
 
         def find_needle_in_haystack(output, row_index):
             # This is the function that will be called for each row of the dataframe
-            label = "UNANSWERABLE"
+            label = "unanswerable"
             row = df.iloc[row_index]
             needle = row['needle_rnd_number']
             print(f"🔍 Looking for the needle: {needle} in {output}")
@@ -288,7 +288,7 @@ class LLMNeedleHaystackTester:
             else:
                 # If the needle is not in the output, then it is unanswerable
                 print(f"❌ Did not find the needle. row: {row}, needle: {needle}, output: {output}")
-                label = "UNANSWERABLE"    
+                label = "unanswerable"    
             return {
                 'label': label,
                 'needle': needle
@@ -339,7 +339,7 @@ class LLMNeedleHaystackTester:
             results = self.create_contexts(needle_rnd_number, insert_needle, random_city, trim_context, context_length, depth_percent)
             contexts.append(results)
         df = pd.DataFrame(contexts)
-        relevance_classifications = llm_generate(
+        haystack_test_results = llm_generate(
             dataframe=df,
             template=template,
             model=model,
@@ -350,7 +350,7 @@ class LLMNeedleHaystackTester:
             output_parser=find_needle_in_haystack,
         )
         print("Negative Test")
-        percentage_unanswerable = (relevance_classifications['label'] == 'unanswerable').mean() * 100
+        percentage_unanswerable = (haystack_test_results['label'] == 'unanswerable').mean() * 100
         print(f"Percentage of 'unanswerable': {percentage_unanswerable:.2f}%")
         return contexts
 

--- a/LLMNeedleHaystackTester.py
+++ b/LLMNeedleHaystackTester.py
@@ -6,10 +6,8 @@ import os
 import tiktoken
 import glob
 import json
-from anthropic import AsyncAnthropic, Anthropic
-from dotenv import load_dotenv
+from anthropic import Anthropic
 import numpy as np
-from openai import AsyncOpenAI
 import pandas as pd
 import random
 import nest_asyncio
@@ -17,10 +15,8 @@ import matplotlib.pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap, Normalize
 from phoenix.experimental.evals.models import LiteLLMModel
 
-import asyncio
 from phoenix.experimental.evals import (
     OpenAIModel,
-    download_benchmark_dataset,
     llm_classify,
 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,6 @@ typing_extensions==4.8.0
 urllib3==2.1.0
 yarl==1.9.3
 arize-phoenix==2.2.1
+litellm==1.16.19
+nest-asyncio==1.5.8
+matplotlib==3.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ typing-inspect==0.9.0
 typing_extensions==4.8.0
 urllib3==2.1.0
 yarl==1.9.3
+arize-phoenix==2.2.1


### PR DESCRIPTION
This moves this repo to use `llm_generate` over classify as it is doing a very specific task of searching for a random number per row. This PR adds pinned versions to requirements txt and also cleans things up a bit.